### PR TITLE
Add FastAPI auth and image gallery search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.db
+uploads/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # TrailCamPro
+
+A minimal FastAPI application for uploading trail camera images and auto-tagging wildlife.
+
+## Features
+- User registration and login with JWT authentication
+- Authenticated camera creation and image upload
+- Browse images per camera with simple filtering
+- Simple AI-based tagging using filename cues and brightness heuristic
+
+## Development
+Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+Run the app:
+```bash
+uvicorn app.main:app --reload
+```
+
+Use the API:
+
+- Register a user: `POST /users/register`
+- Obtain a token: `POST /users/login`
+- Include the token in `Authorization: Bearer <token>` header when creating cameras and uploading images.
+
+Run tests:
+```bash
+pytest
+```

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timedelta
+from typing import Optional
+import os
+
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.orm import Session
+
+from . import models
+from .database import get_db
+
+SECRET_KEY = os.getenv("SECRET_KEY", "secretkey")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/users/login")
+
+
+def verify_password(plain_password, hashed_password):
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password):
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def decode_access_token(token: str):
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id: str = payload.get("sub")
+        if user_id is None:
+            raise JWTError()
+        return int(user_id)
+    except JWTError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+
+def get_current_user(db: Session = Depends(get_db), token: str = Depends(oauth2_scheme)):
+    user_id = decode_access_token(token)
+    user = db.query(models.User).get(user_id)
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+    return user

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,16 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base, Session
+from typing import Generator
+
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+from .routers import users, cameras
+from .database import Base, engine
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="TrailCamPro")
+
+app.include_router(users.router)
+app.include_router(cameras.router)

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,32 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+from datetime import datetime
+
+from .database import Base
+
+class User(Base):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True)
+    hashed_password = Column(String)
+    role = Column(String, default="user")
+    cameras = relationship("Camera", back_populates="owner")
+
+class Camera(Base):
+    __tablename__ = "cameras"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True)
+    owner_id = Column(Integer, ForeignKey("users.id"))
+    owner = relationship("User", back_populates="cameras")
+    images = relationship("Image", back_populates="camera")
+
+class Image(Base):
+    __tablename__ = "images"
+    id = Column(Integer, primary_key=True, index=True)
+    filename = Column(String, index=True)
+    uploaded_at = Column(DateTime, default=datetime.utcnow)
+    camera_id = Column(Integer, ForeignKey("cameras.id"))
+    camera = relationship("Camera", back_populates="images")
+    species = Column(String, nullable=True)
+    antler_class = Column(String, nullable=True)
+    time_of_day = Column(String, nullable=True)

--- a/app/routers/cameras.py
+++ b/app/routers/cameras.py
@@ -1,0 +1,71 @@
+from fastapi import APIRouter, Depends, UploadFile, File, HTTPException
+from sqlalchemy.orm import Session
+from typing import List, Optional
+from pathlib import Path
+
+from .. import models, schemas, utils, auth
+from ..database import get_db
+
+router = APIRouter(prefix="/cameras", tags=["cameras"])
+
+
+def save_upload(file: UploadFile, dest: Path) -> Path:
+    with dest.open("wb") as buffer:
+        buffer.write(file.file.read())
+    return dest
+
+
+@router.post("/", response_model=schemas.Camera)
+def create_camera(
+    camera: schemas.CameraCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    db_cam = models.Camera(name=camera.name, owner_id=current_user.id)
+    db.add(db_cam)
+    db.commit()
+    db.refresh(db_cam)
+    return db_cam
+
+
+@router.post("/{camera_id}/upload", response_model=List[schemas.Image])
+def upload_images(
+    camera_id: int,
+    files: List[UploadFile] = File(...),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    camera = db.query(models.Camera).get(camera_id)
+    if not camera or camera.owner_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Camera not found")
+    saved = []
+    Path("uploads").mkdir(exist_ok=True)
+    for upload in files:
+        path = Path("uploads") / upload.filename
+        save_upload(upload, path)
+        species, antler, tod = utils.analyze_image(path)
+        img = models.Image(filename=upload.filename, camera_id=camera_id, species=species, antler_class=antler, time_of_day=tod)
+        db.add(img)
+        db.commit()
+        db.refresh(img)
+        saved.append(img)
+    return saved
+
+
+@router.get("/{camera_id}/images", response_model=List[schemas.Image])
+def list_images(
+    camera_id: int,
+    species: Optional[str] = None,
+    time_of_day: Optional[str] = None,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    camera = db.query(models.Camera).get(camera_id)
+    if not camera or camera.owner_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Camera not found")
+    query = db.query(models.Image).filter(models.Image.camera_id == camera_id)
+    if species:
+        query = query.filter(models.Image.species == species)
+    if time_of_day:
+        query = query.filter(models.Image.time_of_day == time_of_day)
+    return query.all()

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from fastapi.security import OAuth2PasswordRequestForm
+
+from .. import models, schemas, auth
+from ..database import get_db
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.post("/register", response_model=schemas.User)
+def register(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    if db.query(models.User).filter(models.User.username == user.username).first():
+        raise HTTPException(status_code=400, detail="Username taken")
+    hashed = auth.get_password_hash(user.password)
+    db_user = models.User(username=user.username, hashed_password=hashed)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+@router.post("/login")
+def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
+    user = db.query(models.User).filter(models.User.username == form_data.username).first()
+    if not user or not auth.verify_password(form_data.password, user.hashed_password):
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+    access_token = auth.create_access_token({"sub": str(user.id)})
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.get("/me", response_model=schemas.User)
+def read_users_me(current_user: models.User = Depends(auth.get_current_user), db: Session = Depends(get_db)):
+    return current_user

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from typing import List, Optional
+from pydantic import BaseModel
+
+class ImageBase(BaseModel):
+    filename: str
+
+class ImageCreate(ImageBase):
+    pass
+
+class Image(ImageBase):
+    id: int
+    uploaded_at: datetime
+    species: Optional[str] = None
+    antler_class: Optional[str] = None
+    time_of_day: Optional[str] = None
+
+    class Config:
+        orm_mode = True
+
+class CameraBase(BaseModel):
+    name: str
+
+class CameraCreate(CameraBase):
+    pass
+
+class Camera(CameraBase):
+    id: int
+    images: List[Image] = []
+
+    class Config:
+        orm_mode = True
+
+class UserBase(BaseModel):
+    username: str
+
+class UserCreate(UserBase):
+    password: str
+
+class User(UserBase):
+    id: int
+    role: str
+    cameras: List[Camera] = []
+
+    class Config:
+        orm_mode = True

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,40 @@
+from PIL import Image as PILImage
+from pathlib import Path
+
+# Placeholder AI tagging
+
+def analyze_image(image_path: Path):
+    # For demo, just return dummy data based on filename
+    name = image_path.stem.lower()
+    species = None
+    if "deer" in name:
+        species = "deer"
+    elif "turkey" in name:
+        species = "turkey"
+    elif "coyote" in name:
+        species = "coyote"
+
+    antler_class = None
+    if species == "deer":
+        if "8" in name:
+            antler_class = "8-point"
+        elif "spike" in name:
+            antler_class = "spike"
+        elif "doe" in name:
+            antler_class = "doe"
+
+    # Determine time of day using simple brightness heuristic
+    try:
+        im = PILImage.open(image_path)
+        grayscale = im.convert("L")
+        brightness = sum(grayscale.getdata()) / (255 * im.width * im.height)
+        if brightness > 0.6:
+            tod = "day"
+        elif brightness < 0.3:
+            tod = "night"
+        else:
+            tod = "dawn/dusk"
+    except Exception:
+        tod = None
+
+    return species, antler_class, tod

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+python-multipart
+python-jose
+passlib[bcrypt]
+Pillow
+pytest
+httpx

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,41 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.main import app
+from app.database import Base, engine
+
+Base.metadata.create_all(bind=engine)
+client = TestClient(app)
+
+
+def test_register_and_login():
+    response = client.post("/users/register", json={"username": "test", "password": "test"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["username"] == "test"
+
+    response = client.post("/users/login", data={"username": "test", "password": "test"})
+    assert response.status_code == 200
+    assert "access_token" in response.json()
+
+
+def test_upload_images(tmp_path):
+    client.post("/users/register", json={"username": "u2", "password": "pw"})
+    token = client.post("/users/login", data={"username": "u2", "password": "pw"}).json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    cam = client.post("/cameras/", json={"name": "cam1"}, headers=headers).json()
+    img_path = tmp_path / "deer_day.jpg"
+    with open(img_path, "wb") as f:
+        f.write(os.urandom(1024))
+    with open(img_path, "rb") as f:
+        files = {"files": ("deer_day.jpg", f, "image/jpeg")}
+        response = client.post(f"/cameras/{cam['id']}/upload", files=files, headers=headers)
+    assert response.status_code == 200
+    data = response.json()[0]
+    assert data["filename"] == "deer_day.jpg"
+    list_resp = client.get(f"/cameras/{cam['id']}/images", headers=headers)
+    assert list_resp.status_code == 200
+    assert len(list_resp.json()) == 1


### PR DESCRIPTION
## Summary
- secure camera routes using JWT auth
- use owner id from auth for camera creation and uploads
- add endpoint to list images with simple filters
- document auth usage in README
- update tests for new auth flow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d2578ad5483328a0d37b115af9201